### PR TITLE
Feature: namespace prefix for witness id

### DIFF
--- a/acdh_collatex_utils/__init__.py
+++ b/acdh_collatex_utils/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Peter Andorfer"""
 __email__ = 'peter.andorfer@oeaw.ac.at'
-__version__ = '1.11.0'
+__version__ = '1.12.0'

--- a/acdh_collatex_utils/post_process.py
+++ b/acdh_collatex_utils/post_process.py
@@ -72,7 +72,7 @@ def merge_tei_fragments(files):
     return full_doc
 
 
-def make_full_tei_doc(input_file):
+def make_full_tei_doc(input_file, wit_prefix=None):
     """ takes the rusult of merged collated tei fragments\
         and returns a valid TEI document as TeiReader object"""
     tei_dummy = TeiReader(TEI_DUMMY_STRING)
@@ -86,9 +86,13 @@ def make_full_tei_doc(input_file):
             wit_set.add(w[1:])
 
     for x in list(sorted(wit_set)):
+        if wit_prefix is not None:
+            wit_id = f"{wit_prefix}__{x}"
+        else:
+            wit_id = x
         w_node = ET.Element("{http://www.tei-c.org/ns/1.0}witness", nsmap={None: "http://www.tei-c.org/ns/1.0"})
-        w_node.attrib['{http://www.w3.org/XML/1998/namespace}id'] = x
-        w_node.text = x
+        w_node.attrib['{http://www.w3.org/XML/1998/namespace}id'] = wit_id
+        w_node.text = wit_id
         list_wit_node.append(w_node)
     for x in crit_app.any_xpath('./*'):
         body.append(x)

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/acdh-oeaw/acdh_collatex_utils',
-    version='1.11.0',
+    version='1.12.0',
     zip_safe=False,
 )

--- a/tests/test_acdh_collatex_utils.py
+++ b/tests/test_acdh_collatex_utils.py
@@ -85,7 +85,7 @@ class TestAcdh_collatex_utils(unittest.TestCase):
             f.write(ET.tostring(full_doc, encoding='UTF-8').decode('utf-8'))
 
     def test_005_make_full_tei_doc(self):
-        full_tei = make_full_tei_doc(INPUT_FILE)
+        full_tei = make_full_tei_doc(INPUT_FILE, wit_prefix=None)
         root = full_tei.tree
         self.assertEqual(
             "{http://www.tei-c.org/ns/1.0}TEI", f"{root.tag}"


### PR DESCRIPTION
PR Checklist

[x] This comment contains a description of changes (with reason)
[x] Referenced issue is linked
[] If you've fixed a bug or added code that should be tested, add tests!
[x] Documentation in docs is updated

Description of changes
* added optional prefix for witness xml:id

Technical details
* make_full_tei_doc() takes addtional argument (wit_prefix) as string / default  = None

Additional context

